### PR TITLE
Makefile: fix ghdlsynth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERILATOR_FLAGS=-O3 -Wno-fatal -Wno-CASEOVERLAP -Wno-UNOPTFLAT #--trace
 
 # fpga-toolchain builds have ghdl plugin built in, otherwise need
 # -m ghdl.so
-GHDLSYNTH ?= $(shell (yosys -H | grep -q ghdl) || echo -m ghdl.so)
+GHDLSYNTH ?= $(shell (yosys -p help | grep -q ghdl) || echo -m ghdl.so)
 YOSYS     ?= yosys
 NEXTPNR   ?= nextpnr-ecp5
 ECPPACK   ?= ecppack


### PR DESCRIPTION
yosys (post 0.13) changed it's command line handling so now -H drops to
a yosys shell, cuasing the build to hang.

Instead run -p help to print the list of commands.

See https://github.com/YosysHQ/yosys/pull/3099 or
https://github.com/hdl/conda-eda/commit/e353966369262c4eb2e0e7f10a8cdbe4be46cf8d

Signed-off-by: Joel Stanley <joel@jms.id.au>